### PR TITLE
Problem: Wrong canary url

### DIFF
--- a/chains/testnet/mantra-canary-net.json
+++ b/chains/testnet/mantra-canary-net.json
@@ -1,17 +1,17 @@
 {
-  "chain_name": "MANTRA-Canary-Net",
+  "chain_name": "MANTRA-Canary",
   "coingecko": "om",
   "type": "testnet",
   "api": [
     {
       "provider": "MANTRA",
-      "address": "https://api.canary-net.mantrachain.dev"
+      "address": "https://api.archive.canary.mantrachain.dev"
     }
   ],
   "rpc": [
     {
       "provider": "MANTRA",
-      "address": "https://rpc.canary-net.mantrachain.dev"
+      "address": "https://rpc.archive.canary.mantrachain.dev"
     }
   ],
   "snapshot_provider": "",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MANTRA-Canary network configuration with a streamlined network name and revised endpoint addresses for both API and RPC services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->