### PR TITLE
Problem: Cannot suggest OMStead EVM chain to Keplr

### DIFF
--- a/chains/mainnet/2_mantra-omstead.json
+++ b/chains/mainnet/2_mantra-omstead.json
@@ -1,5 +1,5 @@
 {
-    "chain_name": "MANTRA-OMStead-EVM",
+    "chain_name": "MANTRA OMStead",
     "coingecko": "om",
     "type": "testnet",
     "api": [
@@ -35,5 +35,20 @@
       "eth-address-gen", 
       "eth-key-sign",
       "eth-secp256k1-cosmos"
-    ]
+    ],
+    "evm": {
+        "chainId": "0x1ED0",
+        "chainName": "MANTRA OMStead EVM",
+        "nativeCurrency": {
+            "name": "MANTRA",
+            "symbol": "OM",
+            "decimals": 18
+        },
+        "rpcUrls": [
+            "https://evm.omstead.io"
+        ],
+        "iconUrls": [
+            "https://assets.mantra.finance/images/networks/dukong.svg"
+        ]
+    }
 }

--- a/src/modules/wallet/suggest.vue
+++ b/src/modules/wallet/suggest.vue
@@ -7,6 +7,7 @@ import { onMounted } from 'vue';
 
 const error = ref("")
 const conf = ref("")
+const evmConf = ref<string | null>(null)
 const dashboard = useDashboard()
 const selected = ref({} as ChainConfig)
 const wallet = ref("leap")
@@ -90,6 +91,11 @@ async function initParamsForKeplr() {
         },
         features: chain.keplrFeatures || [],
     }, null, '\t')
+
+  // Reference: https://docs.keplr.app/api/multi-ecosystem-support/evm
+  if (chain.evm) {
+    evmConf.value = JSON.stringify(chain.evm, null, '\t')
+  }
 }
 
 async function initSnap() {
@@ -137,13 +143,26 @@ function suggest() {
       })
     }
   } else if (wallet.value === "keplr") {
+    // One click suggest 2 chains
+    // @ts-ignore
+    if (window.keplr) {
+      // @ts-ignore
+      window.keplr.experimentalSuggestChain(JSON.parse(conf.value)).catch(e => {
+        error.value = e
+      })
+
+      // Reference: https://docs.keplr.app/api/multi-ecosystem-support/evm#example-usage
+      if (evmConf.value !== null) {
         // @ts-ignore
-        if (window.keplr) {
-            // @ts-ignore
-            window.keplr.experimentalSuggestChain(JSON.parse(conf.value)).catch(e => {
-                error.value = e
-            })
-        }
+        window.keplr.ethereum.request({
+          method: "wallet_addEthereumChain",
+          params: [JSON.parse(evmConf.value)]
+        }).catch(e => {
+          error.value = e
+          console.log(e);
+        })
+      }
+    }
     } else {
         suggestChain(JSON.parse(conf.value));
     }
@@ -177,6 +196,10 @@ function suggest() {
         </div>
         <div class="text-main mt-5">
             <textarea v-model="conf" class="textarea textarea-bordered w-full" rows="15"></textarea>
+          <div v-if="evmConf !== null">
+            <hr />
+            <textarea v-model="evmConf" class="textarea textarea-bordered w-full" rows="15"></textarea>
+          </div>
         </div>
         <div class="mt-4 mb-4">
 

--- a/src/modules/wallet/suggest.vue
+++ b/src/modules/wallet/suggest.vue
@@ -141,6 +141,19 @@ function suggest() {
       window.leap.experimentalSuggestChain(JSON.parse(conf.value)).catch(e => {
         error.value = e
       })
+
+      // Reference: https://docs.keplr.app/api/multi-ecosystem-support/evm#example-usage
+      if (evmConf.value !== null) {
+        // @ts-ignore
+        window.leap.ethereum.request({
+          method: "wallet_addEthereumChain",
+          params: [JSON.parse(evmConf.value)]
+        })// @ts-ignore
+          .catch(e => {
+          error.value = e
+          console.log(e);
+        })
+      }
     }
   } else if (wallet.value === "keplr") {
     // One click suggest 2 chains
@@ -157,7 +170,8 @@ function suggest() {
         window.keplr.ethereum.request({
           method: "wallet_addEthereumChain",
           params: [JSON.parse(evmConf.value)]
-        }).catch(e => {
+        })// @ts-ignore
+          .catch(e => {
           error.value = e
           console.log(e);
         })

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -93,6 +93,18 @@ export interface ChainConfig {
     address_limit: number;
     fees: string;
   };
+  // For EVM chain only
+  evm? : {
+    chainId: string;
+    chainName: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string;
+      decimals: number;
+    }
+    rpcUrls: string[];
+    iconUrls: string[];
+  };
 }
 
 export interface LocalConfig {
@@ -132,6 +144,18 @@ export interface LocalConfig {
     ip_limit: number;
     address_limit: number;
     fees: string;
+  };
+  // For EVM chain only
+  evm? : {
+    chainId: string;
+    chainName: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string;
+      decimals: number;
+    }
+    rpcUrls: string[];
+    iconUrls: string[];
   };
 }
 
@@ -193,6 +217,9 @@ export function fromLocal(lc: LocalConfig): ChainConfig {
   conf.keplrPriceStep = lc.keplr_price_step;
   conf.themeColor = lc.theme_color;
   conf.faucet = lc.faucet;
+  if (lc.evm) {
+    conf.evm = lc.evm;
+  }
   return conf;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for EVM-compatible chain configurations, allowing users to view, edit, and suggest EVM chain parameters alongside Cosmos chains when integrating with Keplr and Leap wallets.
  - The interface now displays both Cosmos and EVM chain configuration details for eligible networks.
  - Updated chain configurations to include detailed EVM network metadata for improved wallet compatibility.

- **Bug Fixes**
  - Improved error handling when suggesting EVM chains to the Keplr and Leap wallets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->